### PR TITLE
Add Ops availability scripts and workflow

### DIFF
--- a/.github/workflows/ops-availability.yml
+++ b/.github/workflows/ops-availability.yml
@@ -1,0 +1,25 @@
+name: Ops Availability
+
+on:
+  schedule:
+    - cron: '0 20 * * 1-5'
+    - cron: '0 22 * * 1-5'
+  workflow_dispatch:
+
+jobs:
+  update-availability:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm ci
+      - name: Fetch next Ops
+        run: node scripts/get-next-ops.js > next.json
+        env:
+          SCHEDULER_API_URL: ${{ secrets.SCHEDULER_API_URL }}
+      - name: Flip availability
+        run: node scripts/flip-availability.js next.json
+        env:
+          RR_API_KEY: ${{ secrets.RR_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -5,3 +5,19 @@ Fetches “next Ops” from our Scheduler app’s public API (no auth),
 POSTs to our “Round Robin”–style app to mark that user Unavailable,
 
 Flips Ops user back to Available (“By Schedule”) at the end of their day.
+
+## Usage
+
+Set the following secrets in your GitHub repository settings:
+
+- `SCHEDULER_API_URL` – URL to the Scheduler endpoint returning the next Ops shift.
+- `RR_API_KEY` – API token for the Round Robin availability service.
+
+The workflow `.github/workflows/ops-availability.yml` runs Monday–Friday at 4 pm and 6 pm ET. It fetches the upcoming Ops user via `get-next-ops.js` and then updates availability with `flip-availability.js`.
+
+Run the scripts locally with:
+
+```bash
+node scripts/get-next-ops.js > next.json
+node scripts/flip-availability.js next.json
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "ops-blocker",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ops-blocker",
+      "version": "1.0.0",
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "ops-blocker",
+  "version": "1.0.0",
+  "description": "A tiny standalone Node.js utility and GitHub Actions workflow that, twice a day (Mon–Fri at 4 pm and 6 pm ET),",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/scripts/flip-availability.js
+++ b/scripts/flip-availability.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+
+const fs = require('fs/promises');
+
+const file = process.argv[2];
+if (!file) {
+  console.error('Usage: node flip-availability.js <file>');
+  process.exit(1);
+}
+
+const { RR_API_KEY } = process.env;
+if (!RR_API_KEY) {
+  console.error('RR_API_KEY environment variable not set');
+  process.exit(1);
+}
+
+async function setAvailability(userId, status) {
+  const res = await fetch('https://other.app/api/set-availability', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${RR_API_KEY}`,
+    },
+    body: JSON.stringify({ userId, status }),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Failed to set availability for ${userId}: ${res.status} ${res.statusText} ${text}`);
+  }
+}
+
+(async () => {
+  try {
+    const data = JSON.parse(await fs.readFile(file, 'utf8'));
+    const nextUserId = data.next?.userId || data.userId || data.nextUserId;
+    const currentUserId = data.current?.userId || data.currentUserId;
+
+    if (nextUserId) {
+      await setAvailability(nextUserId, 'Unavailable');
+    } else {
+      console.warn('No upcoming user found in JSON');
+    }
+
+    if (currentUserId) {
+      await setAvailability(currentUserId, 'By%20Schedule');
+    } else {
+      console.warn('No current user found in JSON');
+    }
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+})();

--- a/scripts/get-next-ops.js
+++ b/scripts/get-next-ops.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+const { SCHEDULER_API_URL } = process.env;
+
+if (!SCHEDULER_API_URL) {
+  console.error('SCHEDULER_API_URL environment variable not set');
+  process.exit(1);
+}
+
+(async () => {
+  try {
+    const res = await fetch(SCHEDULER_API_URL);
+    if (!res.ok) {
+      throw new Error(`Failed to fetch ${SCHEDULER_API_URL}: ${res.status} ${res.statusText}`);
+    }
+    const data = await res.json();
+    process.stdout.write(JSON.stringify(data));
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- add scripts to fetch next Ops and flip availability
- schedule twice-daily workflow
- document secrets needed to run the workflow

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_686590c466f48321822144c90d5fb624